### PR TITLE
Update through2, tap-parser and chalk

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "tap-dot": "bin/dot"
   },
   "dependencies": {
-    "through2": "^0.4.1",
-    "tap-parser": "^0.4.3",
+    "through2": "^0.6.1",
+    "tap-parser": "^0.7.0",
     "duplexer": "^0.1.1",
-    "chalk": "^0.4.0"
+    "chalk": "^0.5.1"
   }
 }


### PR DESCRIPTION
through2 v0.5.x includes some performance improvements.
rvagg/through2@81fd3c612231c4c024ceceec3ac515cc8a2f6c51
