### PR TITLE
Bugfix: replace tap-parser with tap-out

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -16,28 +16,28 @@ var lastComment;
 out.push('\n');
 
 function outPush (str) {
-  
+
   out.push('  ' + str);
 };
 
 tap.on('comment', function (comment) {
-  
+
   lastComment = comment;
 });
 
 var firstTestDone = false;
 
 tap.on('assert', function (res) {
-  
+
   var color = (res.ok) ? 'green' : 'red';
-  
+
   assertCount +=1;
-  
+
   if (res.ok) {
     (firstTestDone)
       ? out.push(chalk[color]('.'))
       : outPush(chalk[color]('.'));
-      
+
     firstTestDone = true;
   }
   if (!res.ok) {
@@ -46,18 +46,18 @@ tap.on('assert', function (res) {
 });
 
 tap.on('extra', function (str) {
-  
+
   if (str !== '') extra.push(str);
 });
 
 tap.on('results', function (res) {
-  
+
   if (res.fail.length) {
     errors = res.fail;
     outPush('\n\n\n');
     outputExtra();
   }
-  
+
   if (!res.ok && assertCount === 0) {
     outPush('\n  ' + chalk.red('Failed:') + ' No assertions found.\n\n');
     process.exit(1);
@@ -68,31 +68,31 @@ tap.on('results', function (res) {
   }
   else if (res.fail.length || !res.ok) {
     statsOutput();
-    
+
     outPush(chalk.red(res.fail.length + ' failed'));
-    
+
     var past = (res.fail.length == 1) ? 'was' : 'were';
     var plural = (res.fail.length == 1) ? 'failure' : 'failures';
-    
+
     outPush('\n\n');
     outPush(chalk.red('Failed Tests: '));
     outPush('There ' + past + ' ' + chalk.red(res.fail.length) + ' ' + plural + '\n\n');
-    
+
     res.fail.forEach(function (error) {
       outPush('  ' + chalk.red('x') + ' ' + error.name + '\n');
     });
-    
+
     outPush('\n');
   }
   else{
     statsOutput();
-    
+
     outPush('\n');
     outPush(chalk.green('Pass!') + '\n');
   }
-  
+
   function statsOutput () {
-    
+
     outPush('\n\n')
     outPush(res.asserts.length + ' tests\n');
     outPush(chalk.green(res.pass.length + ' passed\n'));
@@ -100,7 +100,7 @@ tap.on('results', function (res) {
 });
 
 function outputExtra () {
-  
+
   console.log(extra.join('\n'));
 }
 
@@ -109,7 +109,7 @@ process.stdin
   .pipe(process.stdout);
 
 process.on('exit', function () {
-  
+
   if (errors.length) {
     process.exit(1);
   }

--- a/bin/dot
+++ b/bin/dot
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 
 var through = require('through2');
-var parser = require('tap-parser');
-var duplexer = require('duplexer');
+var parser = require('tap-out');
 var chalk = require('chalk');
 var out = through();
 var tap = parser();
-var dup = duplexer(tap, out);
 var currentTestName = '';
 var errors = [];
 var extra = [];
 var assertCount = 0;
 var lastComment;
+
+process.stdin.pipe(tap);
 
 out.push('\n');
 
@@ -50,23 +50,13 @@ tap.on('extra', function (str) {
   if (str !== '') extra.push(str);
 });
 
-tap.on('results', function (res) {
+tap.on('output', function (res) {
 
-  if (res.fail.length) {
+  if (res.fail && res.fail.length) {
     errors = res.fail;
     outPush('\n\n\n');
     outputExtra();
-  }
 
-  if (!res.ok && assertCount === 0) {
-    outPush('\n  ' + chalk.red('Failed:') + ' No assertions found.\n\n');
-    process.exit(1);
-  }
-  else if (!res.ok && res.fail.length === 0) {
-    outPush('\n')
-    process.exit(1);
-  }
-  else if (res.fail.length || !res.ok) {
     statsOutput();
 
     outPush(chalk.red(res.fail.length + ' failed'));
@@ -94,7 +84,7 @@ tap.on('results', function (res) {
   function statsOutput () {
 
     outPush('\n\n')
-    outPush(res.asserts.length + ' tests\n');
+    outPush(res.tests.length + ' tests\n');
     outPush(chalk.green(res.pass.length + ' passed\n'));
   }
 });
@@ -104,9 +94,7 @@ function outputExtra () {
   console.log(extra.join('\n'));
 }
 
-process.stdin
-  .pipe(dup)
-  .pipe(process.stdout);
+out.pipe(process.stdout);
 
 process.on('exit', function () {
 

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "tap-dot": "bin/dot"
   },
   "dependencies": {
-    "through2": "^0.6.1",
-    "tap-parser": "^0.7.0",
+    "chalk": "^0.5.1",
     "duplexer": "^0.1.1",
-    "chalk": "^0.5.1"
+    "tap-parser": "^0.7.0",
+    "through2": "^0.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "tap-dot": "bin/dot"
   },
   "dependencies": {
-    "chalk": "^0.5.1",
+    "chalk": "^1.1.1",
     "tap-out": "^1.3.2",
-    "through2": "^0.6.1"
+    "through2": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   },
   "dependencies": {
     "chalk": "^0.5.1",
-    "duplexer": "^0.1.1",
-    "tap-parser": "^0.7.0",
+    "tap-out": "^1.3.2",
     "through2": "^0.6.1"
   }
 }


### PR DESCRIPTION
There were certain conditions that would lead `tap-dot` to return `1` exit code despite all tests passing. This has been fixed by replacing `tap-parser` with your own tap parser `tap-out`. I also updated `chalk`/`through2` to their latest versions. 

I would have added a test fixture, but there weren't any tests. Given the purpose of this module, presumably you use either `node-tap` or `tape`, but I didn't want to speculate and possibly do unnecessary work.