### PR TITLE
Fail test suite if there are zero tests

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -52,7 +52,7 @@ tap.on('extra', function (str) {
 
 tap.on('output', function (res) {
 
-  if (res.fail && res.fail.length) {
+  if (res.fail && res.fail.length || assertCount === 0) {
     errors = res.fail;
     outPush('\n\n\n');
     outputExtra();
@@ -98,7 +98,7 @@ out.pipe(process.stdout);
 
 process.on('exit', function () {
 
-  if (errors.length) {
+  if (errors.length || assertCount === 0) {
     process.exit(1);
   }
 });


### PR DESCRIPTION
A test suite with zero tests is most likely an error: it can happen if,
for example, the program generating the tap output fails before any
tests are run. Handle this case like [tap-spec](https://github.com/scottcorgan/tap-spec/blob/master/index.js#L69) by failing the test suite.