### PR TITLE
Swap chalk for turbocolor

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -2,7 +2,7 @@
 
 var through = require('through2');
 var parser = require('tap-out');
-var chalk = require('chalk');
+var tc = require('turbocolor');
 var out = through();
 var tap = parser();
 var currentTestName = '';
@@ -35,13 +35,13 @@ tap.on('assert', function (res) {
 
   if (res.ok) {
     (firstTestDone)
-      ? out.push(chalk[color]('.'))
-      : outPush(chalk[color]('.'));
+      ? out.push(tc[color]('.'))
+      : outPush(tc[color]('.'));
 
     firstTestDone = true;
   }
   if (!res.ok) {
-    out.push(chalk[color]('x'));
+    out.push(tc[color]('x'));
   }
 });
 
@@ -56,15 +56,15 @@ tap.on('output', function (res) {
     outPush('\n\n\n');
 
     res.fail.forEach(function (failure) {
-        outPush(chalk.white('---') + '\n');
+        outPush(tc.white('---') + '\n');
 
         // Use the unwrapped out.push here as the raw error is already indented
-        out.push(chalk.white(failure.error.raw) + '\n');
+        out.push(tc.white(failure.error.raw) + '\n');
 
         var stackPadding = '           '
-        out.push(chalk.white(stackPadding + failure.error.stack.replace(/\n/g, '\n  ' + stackPadding)) + '\n');
+        out.push(tc.white(stackPadding + failure.error.stack.replace(/\n/g, '\n  ' + stackPadding)) + '\n');
 
-        outPush(chalk.white('...') + '\n');
+        outPush(tc.white('...') + '\n');
     });
 
     errors = res.fail;
@@ -72,17 +72,17 @@ tap.on('output', function (res) {
 
     statsOutput();
 
-    outPush(chalk.red(res.fail.length + ' failed'));
+    outPush(tc.red(res.fail.length + ' failed'));
 
     var past = (res.fail.length == 1) ? 'was' : 'were';
     var plural = (res.fail.length == 1) ? 'failure' : 'failures';
 
     outPush('\n\n');
-    outPush(chalk.red('Failed Tests: '));
-    outPush('There ' + past + ' ' + chalk.red(res.fail.length) + ' ' + plural + '\n\n');
+    outPush(tc.red('Failed Tests: '));
+    outPush('There ' + past + ' ' + tc.red(res.fail.length) + ' ' + plural + '\n\n');
 
     res.fail.forEach(function (error) {
-      outPush('  ' + chalk.red('x') + ' ' + error.name + '\n');
+      outPush('  ' + tc.red('x') + ' ' + error.name + '\n');
     });
 
     outPush('\n');
@@ -91,14 +91,14 @@ tap.on('output', function (res) {
     statsOutput();
 
     outPush('\n');
-    outPush(chalk.green('Pass!') + '\n');
+    outPush(tc.green('Pass!') + '\n');
   }
 
   function statsOutput () {
 
     outPush('\n\n')
     outPush(res.tests.length + ' tests\n');
-    outPush(chalk.green(res.pass.length + ' passed\n'));
+    outPush(tc.green(res.pass.length + ' passed\n'));
   }
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,27 +4,36 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
       }
+    },
+    "color-convert": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "requires": {
+        "color-name": "1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -36,13 +45,10 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "inherits": {
       "version": "2.0.3",
@@ -99,18 +105,13 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
     "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
     },
     "tap-out": {
       "version": "1.4.2",
@@ -141,6 +142,11 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+    },
+    "turbocolor": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/turbocolor/-/turbocolor-2.3.0.tgz",
+      "integrity": "sha512-Mwf2cXwT8UFj7G97BOhVD7m7kKZhsGdEG8I/FqBz8nA4SskkPLdX1RcQ2rKbfCzGiF9xCaULXd3XcKaWUpbehQ=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "tap-dot": "bin/dot"
   },
   "dependencies": {
-    "chalk": "^1.1.1",
     "tap-out": "^1.3.2",
-    "through2": "^2.0.0"
+    "through2": "^2.0.0",
+    "turbocolor": "^2.3.0"
   }
 }


### PR DESCRIPTION
Hello @scottcorgan! 

This is a PR for your consideration that swaps chalk for [turbocolor](https://github.com/jorgebucaran/turbocolor). See also: https://github.com/scottcorgan/tap-spec/pull/62

<img width="549" alt="screen shot 2018-07-16 at 19 15 44" src="https://user-images.githubusercontent.com/56996/42753700-ac8fbdac-892c-11e8-8330-113c5f7bbbc2.png">

It ought to give tap-dot users a modest perf boost as turbocolor loads **_>20x_** faster and applies styles **_>18x_** faster than chalk for essentially the same API. Let me know if this looks good to you and if you'd like to accept my contribution.

<pre>
# Load Time
chalk: 15.190ms
<b>turbocolor: 0.777ms</b>

# All Colors
chalk × 8,729 ops/sec
<b>turbocolor × 158,383 ops/sec</b>

# Chained Colors
chalk × 1,838 ops/sec
<b>turbocolor × 39,830 ops/sec</b>

# Nested Colors
chalk × 4,049 ops/sec
<b>turbocolor × 59,833 ops/sec</b>
</pre>

More on the benchmarks [here](https://github.com/jorgebucaran/turbocolor/tree/master/bench#benchmarks). Cheers!