### PR TITLE
refactor: replace chalk with colorette

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -2,7 +2,7 @@
 
 var through = require('through2');
 var parser = require('tap-out');
-var chalk = require('chalk');
+var color = require('colorette');
 var out = through();
 var tap = parser();
 var currentTestName = '';
@@ -29,19 +29,19 @@ var firstTestDone = false;
 
 tap.on('assert', function (res) {
 
-  var color = (res.ok) ? 'green' : 'red';
+  var key = (res.ok) ? 'green' : 'red';
 
   assertCount +=1;
 
   if (res.ok) {
     (firstTestDone)
-      ? out.push(chalk[color]('.'))
-      : outPush(chalk[color]('.'));
+      ? out.push(color[key]('.'))
+      : outPush(color[key]('.'));
 
     firstTestDone = true;
   }
   if (!res.ok) {
-    out.push(chalk[color]('x'));
+    out.push(color[key]('x'));
   }
 });
 
@@ -56,15 +56,15 @@ tap.on('output', function (res) {
     outPush('\n\n\n');
 
     res.fail.forEach(function (failure) {
-        outPush(chalk.white('---') + '\n');
+        outPush(color.white('---') + '\n');
 
         // Use the unwrapped out.push here as the raw error is already indented
-        out.push(chalk.white(failure.error.raw) + '\n');
+        out.push(color.white(failure.error.raw) + '\n');
 
         var stackPadding = '           '
-        out.push(chalk.white(stackPadding + failure.error.stack.replace(/\n/g, '\n  ' + stackPadding)) + '\n');
+        out.push(color.white(stackPadding + failure.error.stack.replace(/\n/g, '\n  ' + stackPadding)) + '\n');
 
-        outPush(chalk.white('...') + '\n');
+        outPush(color.white('...') + '\n');
     });
 
     errors = res.fail;
@@ -72,17 +72,17 @@ tap.on('output', function (res) {
 
     statsOutput();
 
-    outPush(chalk.red(res.fail.length + ' failed'));
+    outPush(color.red(res.fail.length + ' failed'));
 
     var past = (res.fail.length == 1) ? 'was' : 'were';
     var plural = (res.fail.length == 1) ? 'failure' : 'failures';
 
     outPush('\n\n');
-    outPush(chalk.red('Failed Tests: '));
-    outPush('There ' + past + ' ' + chalk.red(res.fail.length) + ' ' + plural + '\n\n');
+    outPush(color.red('Failed Tests: '));
+    outPush('There ' + past + ' ' + color.red(res.fail.length) + ' ' + plural + '\n\n');
 
     res.fail.forEach(function (error) {
-      outPush('  ' + chalk.red('x') + ' ' + error.name + '\n');
+      outPush('  ' + color.red('x') + ' ' + error.name + '\n');
     });
 
     outPush('\n');
@@ -91,14 +91,14 @@ tap.on('output', function (res) {
     statsOutput();
 
     outPush('\n');
-    outPush(chalk.green('Pass!') + '\n');
+    outPush(color.green('Pass!') + '\n');
   }
 
   function statsOutput () {
 
     outPush('\n\n')
     outPush(res.tests.length + ' tests\n');
-    outPush(chalk.green(res.pass.length + ' passed\n'));
+    outPush(color.green(res.pass.length + ' passed\n'));
   }
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,45 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-    },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      }
+    "colorette": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.0.5.tgz",
+      "integrity": "sha512-7mcpZLRdXqHLaOhGfKaDD/K7UjLSp6MkrDT6DziQ/HKBxqV3G1yLZAc14UCP8bCQAJTbcvd4k6MGRVYUa4NmHw=="
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -98,19 +68,6 @@
       "requires": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "requires": {
-        "ansi-regex": "^2.0.0"
-      }
-    },
-    "supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "tap-out": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "tap-dot": "bin/dot"
   },
   "dependencies": {
-    "chalk": "^1.1.1",
+    "colorette": "^1.0.5",
     "tap-out": "^1.3.2",
     "through2": "^2.0.0"
   }


### PR DESCRIPTION
This PR replaces chalk with colorette which is [faster](https://github.com/jorgebucaran/colorette#benchmark-results) for a fraction of the [size](https://packagephobia.now.sh/result?p=colorette). 

Related #20 

cc @scottcorgan 