### PR TITLE
Add if statments to avoid issues with basic failed tests

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -56,15 +56,17 @@ tap.on('output', function (res) {
     outPush('\n\n\n');
 
     res.fail.forEach(function (failure) {
-        outPush(chalk.white('---') + '\n');
+        if (failure.error.raw) {
+            outPush(chalk.white('---') + '\n');
 
-        // Use the unwrapped out.push here as the raw error is already indented
-        out.push(chalk.white(failure.error.raw) + '\n');
+            // Use the unwrapped out.push here as the raw error is already indented
+            out.push(chalk.white(failure.error.raw) + '\n');
 
-        var stackPadding = '           '
-        out.push(chalk.white(stackPadding + failure.error.stack.replace(/\n/g, '\n  ' + stackPadding)) + '\n');
+            var stackPadding = '           '
+            if (failure.error.stack) out.push(chalk.white(stackPadding + failure.error.stack.replace(/\n/g, '\n  ' + stackPadding)) + '\n');
 
-        outPush(chalk.white('...') + '\n');
+            outPush(chalk.white('...') + '\n');
+        }
     });
 
     errors = res.fail;


### PR DESCRIPTION
```
1..1
not ok
```

The above is valid TAP which is parsed by `tap-out`, however it currently assumed that a YAML block will always be present, resulting in errors when it's absent. `if` statements have been added to prevent this issue.