### PR TITLE
Replace res.tests with res.asserts

### DIFF
--- a/bin/dot
+++ b/bin/dot
@@ -97,7 +97,7 @@ tap.on('output', function (res) {
   function statsOutput () {
 
     outPush('\n\n')
-    outPush(res.tests.length + ' tests\n');
+    outPush(res.asserts.length + ' tests\n');
     outPush(chalk.green(res.pass.length + ' passed\n'));
   }
 });


### PR DESCRIPTION
```
1..3
ok 1
ok 2
ok 3
```

`tap-out` returns the above as asserts rather than tests. `tap-dot` currently outputs 0 tests 3 passed due to the use of res.tests.